### PR TITLE
docs: update food.md when qty is zero

### DIFF
--- a/project-document/docs/domain-model/group-context/container-aggregate/food.md
+++ b/project-document/docs/domain-model/group-context/container-aggregate/food.md
@@ -19,10 +19,9 @@ The unit can be changed after setting.
 
 ### Quantity (Value Object)
 
-The quantity must be null or more than 0.
-The quantity can be the float.  In that case, the effective digit is 2, and less than that is discarded.
+The quantity can be null or 0.
+It also  can be the float.  In this case, the effective digit is 2, and less than that is discarded.
 The reason for adopting discarding instead of rounding is to avoid increasing quantity which is an unnatural phenomenon.
-When the quantity is 0 by subtraction, the food is deleted.
 
 ### Expiry (Value Object)
 


### PR DESCRIPTION
As we discussed, the quantity of food can be zero and remain in the container, so I deleted this feature from document.