### PR TITLE
PUT `/group/{gorupId}`: Forbid groupName to have null

### DIFF
--- a/web-api/nishiki-web-api.yaml
+++ b/web-api/nishiki-web-api.yaml
@@ -545,7 +545,7 @@ paths:
               properties:
                 groupName:
                   type: string
-                  nullable: true
+                  nullable: false
                   example: new-group
       responses:
         "204":


### PR DESCRIPTION
## Overview
made the groupName's nullable false.